### PR TITLE
Replace Travis-CI by Github Actions

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -1,0 +1,22 @@
+name: Python test
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Prepare test environment
+        run: pip install tox
+      - name: Run tests
+        run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: python
-dist: focal
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-install: pip install tox-travis
-script: tox


### PR DESCRIPTION
Create a simple github workflow file to replace
the old travis-ci that appears to be not that open
source friendly anymore.