### PR TITLE
Release version 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, "README.md"), "r") as f:
 
 setup(
     name='python-yate',
-    version='0.3.1',
+    version='0.4.0',
     packages=['yate'],
     url='https://github.com/eventphone/python-yate',
     license='MIT',
@@ -19,9 +19,10 @@ setup(
     description='An (asyncio enabled) python library for yate IVRs and extmodules',
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: MIT License",
     ],
     install_requires=[


### PR DESCRIPTION
Release new version 0.4.0 with support for
Python 3.7 to 3.10.

This release also fixes handling of hang-up events
correctly for IVRs.