### PR TITLE
Add aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     install_requires=[
+        'aiohttp',
         'async_timeout',
     ],
     entry_points={


### PR DESCRIPTION
`aiohttp` is a [runtime requirement](https://github.com/eventphone/python-yate/blob/master/yate/callgen.py#L7).